### PR TITLE
Download current OpenAPI spec from URL before client generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # deutschland-generator-action
-Github action for the generation process of generating docs and code for the deutschland package
+Github action to generate a Python client library based on a remote OpenAPI specification for use in the `deutschland` package
 
 ## Inputs
 
 | Input                | Required | Default      | Description                                                       | Example                              |
 |----------------------|----------|--------------|-------------------------------------------------------------------|--------------------------------------|
-| `openapi-file`       | true     | openapi.yaml | The path to the OpenAPI document to generate a client library for | ./api/openapi.json                   |
+| `openapi-uri`       | true     |  | The URI of the OpenAPI document to generate a client library for | https://search.dip.bundestag.de/api/v1/openapi.yaml                   |
 | `commit-to-git`      | false    | false        | Should the generated code be added to git                                | true                                 |
 | `upload-to-pypi`     | false    | false        | Should package be uploaded to pypi                                | false                                |
 | `upload-to-testpypi` | false    | false        | Should package be uploaded to testpypi                              | false                                |
@@ -13,8 +13,9 @@ Github action for the generation process of generating docs and code for the deu
 | `testpypi-token`     | false    | 'undefined'  | Token to upload package to testpypi                                | `${{ secrets.TEST_PYPI_API_TOKEN }}` |
 | `python-version`     | true     | 3.7          | Python version to run on                               | 3.8                                  |
 
-If you watn to use your custom templates, put them into a folder called ```deutschland_templates``` inside the root of your repostitory. 
-If it is existing, the action will use the provided templates, if not it will copy over the default templates from the deutschland-generator-action repo.
+If you want to use your custom templates, put them into a folder called ```deutschland_templates``` inside the root of your own repostitory. If it exists, the action will use your templates, if not it will copy over the default templates from this action's repository.
+
+> Note: the downloaded OpenAPI specification will always be saved as `openapi.yaml` on the root level of your repository.
 
 ## Example
 
@@ -32,7 +33,7 @@ jobs:
       - name: "Generate deutschland code"
         uses: wirthual/deutschland-generator-action@v0.8.0
         with:
-          openapi-file: ${{ github.workspace }}/openapi.yaml
+          openapi-uri: https://search.dip.bundestag.de/api/v1/openapi.yaml
           commit-to-git: true
           upload-to-pypi: false
           upload-to-testpypi: true

--- a/action.yaml
+++ b/action.yaml
@@ -65,6 +65,7 @@ runs:
 
     - name: "Download latest OpenAPI spec"
       run: curl ${{ inputs.openapi-uri }} > openapi.yaml
+      shell: bash
 
     - name: "Copy deutschland templates into workspace if it not already exists"
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -1,14 +1,13 @@
 name: "Deutschland Generator Action"
-description: "Generates a client library and docs from an OpenAPI description"
+description: "Generates a client library and docs from an OpenAPI specification"
 branding:
   icon: target
   color: green
 
 inputs:
-  openapi-file:
-    description: "The path to the OpenAPI document to generate a client library for"
+  openapi-uri:
+    description: "The URI to the OpenAPI document to generate a client library for"
     required: true
-    default: 'openapi.yaml'
   commit-to-git:
     description: "Should the generated code be added to git"
     required: false
@@ -41,7 +40,7 @@ runs:
     # Print params of invocation
     - name: "Print params of invocation for book keeping"
       run: |
-        echo "Open Api File:" ${{ inputs.openapi-file }}
+        echo "OpenAPI URI:" ${{ inputs.openapi-uri }}
         echo "Upload-to-pypi:" ${{ inputs.upload-to-pypi == 'true' }}
         echo "Upload-to-testpypi:" ${{ inputs.upload-to-testpypi == 'true'}}
         echo "Pypi Token:" ${{ inputs.pypi-token }} | head -c14
@@ -64,6 +63,9 @@ runs:
         sudo rm -rf ${{ github.workspace }}/python-client
       shell: bash
 
+    - name: "Download latest OpenAPI spec"
+      run: curl ${{ inputs.openapi-uri }} > openapi.yaml
+
     - name: "Copy deutschland templates into workspace if it not already exists"
       run: |
         cp -rn ${{ github.action_path }}/deutschland_templates ${{ github.workspace }}
@@ -74,7 +76,7 @@ runs:
       uses: openapi-generators/openapitools-generator-action@v1
       with:
         generator: python
-        openapi-file: openapi.yaml
+        openapi-uri: openapi.yaml
         config-file: generator_config.yaml
         generator-tag: v6.1.0
 
@@ -131,7 +133,7 @@ runs:
         git config --local user.email "bundesAPI@users.noreply.github.com"
         git config --local user.name "bundesbot"
         git add ${{ github.workspace }}/python-client
-        git commit --allow-empty -m "Generate newest code from openapi.yaml" -a
+        git commit --allow-empty -m "Generate client from current OpenAPI spec" -a
       shell: bash
       if: ${{ inputs.commit-to-git == 'true' }}
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Deutschland Generator Action"
-description: "Generates a client library and docs from an OpenAPI specification"
+description: "Generates a Python client library based on a remote OpenAPI specification for use in the deutschland package"
 branding:
   icon: target
   color: green
@@ -76,7 +76,7 @@ runs:
       uses: openapi-generators/openapitools-generator-action@v1
       with:
         generator: python
-        openapi-uri: openapi.yaml
+        openapi-file: openapi.yaml
         config-file: generator_config.yaml
         generator-tag: v6.1.0
 


### PR DESCRIPTION
This **should** download the current OpenAPI specification from a given URL — what's the best way for testing this? I could run it in a fork of `deutschland`, but wasn't sure if that's the best way.

tldr: I'm using `curl` to overwrite the `openapi.yaml` file (without checking or sanitizing the input URL)